### PR TITLE
add step to validate json file passed for create file

### DIFF
--- a/cmd/server/files.go
+++ b/cmd/server/files.go
@@ -103,6 +103,11 @@ func createFile(logger log.Logger, repo WireFileRepository) http.HandlerFunc {
 				moovhttp.Problem(w, err)
 				return
 			}
+			if err := req.Validate(); err != nil {
+				err = logger.LogErrorf("file validation failed: %v", err).Err()
+				moovhttp.Problem(w, err)
+				return
+			}
 		} else {
 			file, err := wire.NewReader(r.Body).Read()
 			if err != nil {


### PR DESCRIPTION
In `/files/create` API, when the request body is `text/plain`, the Read() function calls the Validate() at the end to validate the `FEDWireMessage` but the same is not done in case when request body is `application/json`

This PR is to add the step to call Validate() on the deserialized `req` struct when the request body is`application/json`